### PR TITLE
add byte pooling

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+   - 1.7
+
+install:
+- go get golang.org/x/tools/cmd/cover
+- export PATH=$PATH:$HOME/gopath/bin
+- go install github.com/vrecan/poolShark/./...
+script: go test ./... -cover --race

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,59 @@
+package pool
+
+import (
+	"sync"
+)
+
+//BytePool is a simple pool of []byte
+type BytePool struct {
+	sliceSize int
+	poolSize  int
+
+	poolSlice [][]byte
+	mutex     *sync.Mutex
+}
+
+//NewBytePool...
+func NewBytePool(poolSize, sliceSize int) *BytePool {
+	return &BytePool{
+		sliceSize: sliceSize,
+		poolSize:  poolSize,
+		poolSlice: make([][]byte, 0),
+		mutex:     &sync.Mutex{},
+	}
+}
+
+//Get returns a cleared []byte
+func (b *BytePool) Get() (value []byte) {
+	b.mutex.Lock()
+	if len(b.poolSlice) > 0 {
+		//pop item off of slice reducing the size of the slice
+		value, b.poolSlice = b.poolSlice[len(b.poolSlice)-1], b.poolSlice[:len(b.poolSlice)-1]
+		b.mutex.Unlock()
+		for i, _ := range value {
+			value[i] = 0
+		}
+		//resize slice to slice size, this will panic if you give it a byte slice smaller then set size
+		value = value[:b.sliceSize]
+
+		return value
+	}
+	b.mutex.Unlock()
+	return make([]byte, b.sliceSize)
+}
+
+//Put adds a slice to the pool
+func (b *BytePool) Put(value []byte) {
+	b.mutex.Lock()
+	if len(b.poolSlice) < b.poolSize {
+		b.poolSlice = append(b.poolSlice, value)
+	}
+	b.mutex.Unlock()
+}
+
+func (b BytePool) Size() int {
+	b.mutex.Lock()
+	s := len(b.poolSlice)
+	b.mutex.Unlock()
+	return s
+}

--- a/pool_test.go
+++ b/pool_test.go
@@ -1,0 +1,46 @@
+package pool
+
+import (
+	// "fmt"
+	log "github.com/cihub/seelog"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestPool(t *testing.T) {
+
+	defer log.Flush()
+	Convey("use pool validate they aren't the same", t, func() {
+
+		pool := NewBytePool(5, 30)
+		bytes := pool.Get()
+		bytes2 := pool.Get()
+		So(bytes, ShouldNotEqual, bytes2)
+	})
+
+	Convey("modify pool, put back on and validate change is not visible with get", t, func() {
+
+		pool := NewBytePool(5, 30)
+		bytes := pool.Get()
+		bytes[0] = byte(1)
+		bytes[1] = byte(1)
+		pool.Put(bytes[:2])
+		bytes2 := pool.Get()
+		So(bytes2, ShouldResemble, make([]byte, 30))
+	})
+
+	Convey("exceed put buffer validate length", t, func() {
+		pool := NewBytePool(1, 30)
+		So(pool.Size(), ShouldEqual, 0)
+		bytes := pool.Get()
+		bytes2 := pool.Get()
+		pool.Put(bytes)
+		So(pool.Size(), ShouldEqual, 1)
+		pool.Put(bytes2)
+		So(pool.Size(), ShouldEqual, 1)
+		bytes3 := pool.Get()
+		So(bytes3, ShouldResemble, make([]byte, 30))
+		So(pool.Size(), ShouldEqual, 0)
+	})
+
+}


### PR DESCRIPTION
I've attempted to use sync.pool and bpool and neither really gave me the performance I wanted. This is a simple [][]byte with a mutex which gave me 3-4x the performance for my application
